### PR TITLE
Implement fallback LLM model and optional headers

### DIFF
--- a/william_ai_assistant/config.py
+++ b/william_ai_assistant/config.py
@@ -9,6 +9,11 @@ load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 OPENROUTER_MODEL = "google/gemini-2.0-flash-exp:free" # Updated to Gemini 2.0 Flash
+OPENROUTER_FALLBACK_MODEL = "deepseek/deepseek-r1-0528:free" # Fallback model
+
+# Optional headers for OpenRouter - can be left empty if not needed
+OPENROUTER_SITE_URL = os.getenv("OPENROUTER_SITE_URL", "") # e.g., "http://localhost" or your actual site
+OPENROUTER_SITE_NAME = os.getenv("OPENROUTER_SITE_NAME", "") # e.g., "William AI Assistant"
 
 # Wake Word
 WAKE_WORD = "hey william"

--- a/william_ai_assistant/william_brain.py
+++ b/william_ai_assistant/william_brain.py
@@ -24,8 +24,13 @@ def get_llm_response(text_input, command_history: list = None):
     """
     headers = {
         "Authorization": f"Bearer {app_config.OPENROUTER_API_KEY}",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
+    # Add optional headers if they are set in config
+    if app_config.OPENROUTER_SITE_URL:
+        headers["HTTP-Referer"] = app_config.OPENROUTER_SITE_URL
+    if app_config.OPENROUTER_SITE_NAME:
+        headers["X-Title"] = app_config.OPENROUTER_SITE_NAME
 
     messages = []
 
@@ -60,52 +65,113 @@ def get_llm_response(text_input, command_history: list = None):
         # "temperature": 0.7   # Example
     }
 
-    try:
-        thought = f"Sending request to LLM ({app_config.OPENROUTER_MODEL}) for input: '{text_input[:70]}...'"
-        print(thought) # Keep console log for dev
-        canvas_utils.update_canvas(thought_process=thought) # Update canvas
+    models_to_try = [app_config.OPENROUTER_MODEL]
+    if app_config.OPENROUTER_FALLBACK_MODEL:
+        models_to_try.append(app_config.OPENROUTER_FALLBACK_MODEL)
 
-        response = requests.post(app_config.OPENROUTER_API_URL, headers=headers, data=json.dumps(payload), timeout=30)
-        response.raise_for_status()
+    last_error = None
 
-        canvas_utils.update_canvas(thought_process="Received response from LLM. Parsing...")
-        response_data = response.json()
+    for model_name in models_to_try:
+        payload["model"] = model_name
+        try:
+            thought = f"Sending request to LLM ({model_name}) for input: '{text_input[:70]}...'"
+            print(thought) # Keep console log for dev
+            canvas_utils.update_canvas(thought_process=thought)
 
-        if response_data.get("choices") and len(response_data["choices"]) > 0:
-            assistant_reply = response_data["choices"][0].get("message", {}).get("content")
-            if assistant_reply:
-                print(f"LLM Response: {assistant_reply}")
-                canvas_utils.update_canvas(thought_process="Successfully extracted LLM reply.")
-                return assistant_reply.strip()
+            response = requests.post(app_config.OPENROUTER_API_URL, headers=headers, data=json.dumps(payload), timeout=30)
+            response.raise_for_status() # Raises HTTPError for bad responses (4XX or 5XX)
+
+            canvas_utils.update_canvas(thought_process=f"Received response from {model_name}. Parsing...")
+            response_data = response.json()
+
+            if response_data.get("choices") and len(response_data["choices"]) > 0:
+                message_content = response_data["choices"][0].get("message", {}).get("content")
+                # The content might be a list of parts or a direct string depending on the model/API version.
+                # Handle if content is a list (e.g., with Gemini 2.0 Flash)
+                if isinstance(message_content, list):
+                    assistant_reply = ""
+                    for part in message_content:
+                        if part.get("type") == "text":
+                            assistant_reply += part.get("text", "")
+                elif isinstance(message_content, str): # Direct string content
+                    assistant_reply = message_content
+                else: # Unexpected format
+                    assistant_reply = None
+
+                if assistant_reply is not None: # Check for None explicitly
+                    print(f"LLM ({model_name}) Response: {assistant_reply}")
+                    canvas_utils.update_canvas(thought_process=f"Successfully extracted LLM reply from {model_name}.")
+                    return assistant_reply.strip()
+                else:
+                    err_msg = f"LLM response format error: 'content' not found or in unexpected format from {model_name}."
+                    print(err_msg)
+                    canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: Malformed AI response.")
+                    last_error = "I received a response, but couldn't understand it." # Keep this generic for user
             else:
-                err_msg = "LLM response format error: 'content' not found."
+                err_msg = f"LLM response format error: 'choices' not found or empty from {model_name}. Response: {response_data}"
                 print(err_msg)
-                canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: Malformed AI response.")
-                return "I received a response, but couldn't understand it."
-        else:
-            err_msg = f"LLM response format error: 'choices' not found or empty. Response: {response_data}"
-            print(err_msg)
-            canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: No choices in AI response.")
-            return "Sorry, I couldn't get a proper response from the AI."
+                canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: No choices in AI response.")
+                last_error = "Sorry, I couldn't get a proper response from the AI." # Keep this generic
 
-    except requests.exceptions.RequestException as e:
-        err_msg = f"Error connecting to OpenRouter API: {e}"
-        print(err_msg)
-        canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: Could not connect to AI service.")
-        # tts_engine.speak("I'm having trouble connecting to my brain. Please check the internet connection and API settings.")
-        return "Error: Could not connect to the AI service."
-    except json.JSONDecodeError as e_json: # Capture the exception instance
-        resp_text = response.text if 'response' in locals() and hasattr(response, 'text') else "Response object or text not available"
-        err_msg = f"Error decoding JSON response from OpenRouter API. Error: {e_json}. Response text: {resp_text[:200]}..."
-        print(err_msg)
-        canvas_utils.update_canvas(thought_process=err_msg, ai_response="Error: Could not understand AI's response (JSON decode).")
-        # tts_engine.speak("I received an unreadable response from my brain.")
-        return "Error: Could not understand the AI's response."
-    except Exception as e:
-        err_msg = f"An unexpected error occurred in get_llm_response: {e}"
-        print(err_msg)
-        canvas_utils.update_canvas(thought_process=err_msg, ai_response="An unexpected error occurred while thinking.")
-        return "An unexpected error occurred while thinking."
+            if last_error and model_name == models_to_try[-1]: # If it's the last model and there was a parsing error
+                return last_error
+            elif last_error: # If there was a parsing error but more models to try
+                continue # Try next model
+
+
+        except requests.exceptions.HTTPError as e_http:
+            err_msg = f"HTTP error with {model_name}: {e_http}"
+            print(err_msg)
+            last_error = f"Error: Could not connect to the AI service ({e_http.response.status_code})."
+            # If it's a rate limit error (429) or server error (5XX) on the primary, try fallback.
+            # For other client errors (4XX) with primary, maybe don't try fallback unless it's auth.
+            # For now, let's try fallback for any HTTP error with the primary model.
+            if model_name == models_to_try[0] and len(models_to_try) > 1:
+                canvas_utils.update_canvas(thought_process=f"{err_msg}. Trying fallback model...")
+                continue # Try next model
+            else: # Error on fallback or no fallback
+                canvas_utils.update_canvas(thought_process=err_msg, ai_response=last_error)
+                return last_error # Return the error from the last attempted model
+
+        except requests.exceptions.RequestException as e_req:
+            err_msg = f"Request error with {model_name}: {e_req}"
+            print(err_msg)
+            last_error = "Error: Could not connect to the AI service (network issue)."
+            if model_name == models_to_try[0] and len(models_to_try) > 1:
+                canvas_utils.update_canvas(thought_process=f"{err_msg}. Trying fallback model...")
+                continue # Try next model
+            else:
+                canvas_utils.update_canvas(thought_process=err_msg, ai_response=last_error)
+                return last_error
+
+        except json.JSONDecodeError as e_json:
+            resp_text = response.text if 'response' in locals() and hasattr(response, 'text') else "Response object or text not available"
+            err_msg = f"Error decoding JSON response from {model_name}. Error: {e_json}. Response text: {resp_text[:200]}..."
+            print(err_msg)
+            last_error = "Error: Could not understand the AI's response (JSON decode)."
+            if model_name == models_to_try[0] and len(models_to_try) > 1:
+                canvas_utils.update_canvas(thought_process=f"{err_msg}. Trying fallback model...")
+                continue # Try next model
+            else:
+                canvas_utils.update_canvas(thought_process=err_msg, ai_response=last_error)
+                return last_error
+
+        except Exception as e: # Catch-all for unexpected errors
+            err_msg = f"An unexpected error occurred with {model_name}: {e}"
+            print(err_msg)
+            last_error = "An unexpected error occurred while thinking."
+            if model_name == models_to_try[0] and len(models_to_try) > 1:
+                canvas_utils.update_canvas(thought_process=f"{err_msg}. Trying fallback model...")
+                continue
+            else:
+                canvas_utils.update_canvas(thought_process=err_msg, ai_response=last_error)
+                return last_error
+
+    # If loop finishes without returning (e.g., models_to_try was empty or all failed silently before error assignment)
+    if last_error:
+        return last_error
+    return "Error: AI service could not be reached or process the request after multiple attempts."
+
 
 if __name__ == '__main__':
     # This is for testing the william_brain.py module independently


### PR DESCRIPTION
- Added OPENROUTER_FALLBACK_MODEL to config.
- Modified william_brain.py to try the primary model and then the fallback model if the primary fails.
- Added support for optional HTTP-Referer and X-Title headers for OpenRouter API calls, controlled by environment variables.
- Improved error handling and logging during LLM requests.